### PR TITLE
Hampus: Login/Register user & fixed names to tables.

### DIFF
--- a/src/main/java/experis/humansvszombies/hvz/controllers/api/KillController.java
+++ b/src/main/java/experis/humansvszombies/hvz/controllers/api/KillController.java
@@ -18,6 +18,7 @@ public class KillController {
     @Autowired
     KillRepository killRepository;
 
+    @CrossOrigin()
     @GetMapping("/api/fetch/kill/all")
     public ResponseEntity<ArrayList<Kill>> getAllKills() {
         ArrayList<Kill> kills = (ArrayList<Kill>)killRepository.findAll();
@@ -38,6 +39,7 @@ public class KillController {
         }
     }
 
+    @CrossOrigin()
     @PostMapping("/api/create/kill/{gameId}/{killerId}/{victimId}")
     public ResponseEntity<Kill> addKill(@RequestBody Kill newKill, @PathVariable Integer gameId, 
     @PathVariable Integer killerId, @PathVariable Integer victimId) {
@@ -89,6 +91,7 @@ public class KillController {
         }
     }
 
+    @CrossOrigin()
     @DeleteMapping("/api/delete/kill/{killId}")
     public ResponseEntity<String> deleteKill(@PathVariable Integer killId) {
         try {

--- a/src/main/java/experis/humansvszombies/hvz/controllers/api/MissionController.java
+++ b/src/main/java/experis/humansvszombies/hvz/controllers/api/MissionController.java
@@ -94,6 +94,7 @@ public class MissionController {
         }
     }
 
+    @CrossOrigin()
     @DeleteMapping("/api/delete/mission/{missionId}")
     public ResponseEntity<String> deleteMission(@PathVariable Integer missionId) {
         try {

--- a/src/main/java/experis/humansvszombies/hvz/controllers/api/UserAccountController.java
+++ b/src/main/java/experis/humansvszombies/hvz/controllers/api/UserAccountController.java
@@ -3,12 +3,15 @@ package experis.humansvszombies.hvz.controllers.api;
 import java.util.ArrayList;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import experis.humansvszombies.hvz.models.tables.UserAccount;
 import experis.humansvszombies.hvz.repositories.UserAccountRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+
 
 
 
@@ -48,6 +51,9 @@ public class UserAccountController {
             return new ResponseEntity<>(newUserAccount, response);
         } catch (IllegalArgumentException e) {
             System.out.println("Exception thrown: newUserAccount was null.");
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        } catch (DataIntegrityViolationException e) {
+            System.out.println("Exception thrown: email or username must be unique.");
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
     }
@@ -115,4 +121,26 @@ public class UserAccountController {
             return new ResponseEntity<>("FAILED", HttpStatus.BAD_REQUEST);
         }
     }
+
+    //SPECIAL METHODS
+    @CrossOrigin()
+    @GetMapping("/api/useraccount/login")
+    public ResponseEntity<String> loginUser(@RequestBody UserAccount userAccount) {
+        //Assume the login will fail.
+        String message = "FAILED";
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        //Check that userAccount isn't null. Then check if the supplied email exists in the database.
+        if (userAccount != null) {
+            UserAccount user = userAccountRepository.findDistinctByEmail(userAccount.getEmail());
+            if (user != null) {
+                //Compare supplied password to account password and return SUCCESS message if login information is correct.
+                if (user.getPassword().equals(userAccount.getPassword())) {
+                    message = "SUCCESS";
+                    status = HttpStatus.OK;
+                }
+            }  
+        }     
+        return new ResponseEntity<>(message, status);
+    }
+    
 }

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/ChatMessage.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/ChatMessage.java
@@ -10,7 +10,7 @@ import javax.persistence.ManyToOne;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
-@Entity
+@Entity(name="chat_message")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "chatMessageId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/Game.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/Game.java
@@ -19,7 +19,7 @@ import org.springframework.data.geo.Point;
 
 import experis.humansvszombies.hvz.models.enums.GameState;
 
-@Entity
+@Entity(name="game")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "gameId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/Kill.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/Kill.java
@@ -13,7 +13,7 @@ import org.springframework.data.geo.Point;
 
 import java.sql.Timestamp;
 
-@Entity
+@Entity(name="kill")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "killId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/Mission.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/Mission.java
@@ -15,7 +15,7 @@ import experis.humansvszombies.hvz.models.enums.MissionState;
 
 import java.sql.Timestamp;
 
-@Entity
+@Entity(name="mission")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "missionId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/Player.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/Player.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import experis.humansvszombies.hvz.models.enums.Faction;
 
-@Entity
+@Entity(name="player")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "playerId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/Squad.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/Squad.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import experis.humansvszombies.hvz.models.enums.Faction;
 
 
-@Entity
+@Entity(name="squad")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "squadId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/SquadCheckin.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/SquadCheckin.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import org.springframework.data.geo.Point;
 
-@Entity
+@Entity(name="squad_checkin")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "squadCheckinId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/SquadMember.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/SquadMember.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import experis.humansvszombies.hvz.models.enums.SquadRank;
 
-@Entity
+@Entity(name="squad_member")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "squadMemberId"

--- a/src/main/java/experis/humansvszombies/hvz/models/tables/UserAccount.java
+++ b/src/main/java/experis/humansvszombies/hvz/models/tables/UserAccount.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import experis.humansvszombies.hvz.models.enums.UserType;
 
-@Entity
+@Entity(name="user_account")
 @JsonIdentityInfo(
     generator = ObjectIdGenerators.PropertyGenerator.class,
     property = "userAccountId"
@@ -39,13 +39,13 @@ public class UserAccount {
     @Column(name="user_type")
     private UserType userType;
 
-    @Column(name="username")
+    @Column(name="username", unique=true)
     private String username;
 
     @Column(name="password")
     private String password;
 
-    @Column(name="email")
+    @Column(name="email", unique=true)
     private String email;
 
 

--- a/src/main/java/experis/humansvszombies/hvz/repositories/UserAccountRepository.java
+++ b/src/main/java/experis/humansvszombies/hvz/repositories/UserAccountRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import experis.humansvszombies.hvz.models.tables.UserAccount;
 
 public interface UserAccountRepository extends JpaRepository<UserAccount, Integer> {
-    
+    UserAccount findDistinctByEmail(String email);
 }

--- a/src/test/java/experis/humansvszombies/hvz/api/UserTests.java
+++ b/src/test/java/experis/humansvszombies/hvz/api/UserTests.java
@@ -84,6 +84,38 @@ public class UserTests {
         assertEquals(HttpStatus.NOT_FOUND, response1.getStatusCode());
     }
 
+    @Test
+    void createDuplicateUser() {
+        ResponseEntity<UserAccount> response = uac.addUserAccount(new UserAccount("Steve", "Harrington", UserType.PLAYER, "Scopes", "icecream", "scopes@email.com"));
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        int stevesId = response.getBody().getUserAccountId();
+        ResponseEntity<UserAccount> response2 = uac.addUserAccount(new UserAccount("Steve", "Harrington", UserType.PLAYER, "Scopes", "icecream", "scopes@email.com"));
+        assertEquals(HttpStatus.BAD_REQUEST, response2.getStatusCode());
+        //Delete steves account again.
+        ResponseEntity<String> deleteResponse = uac.deleteUserAccount(stevesId);
+        assertEquals(HttpStatus.OK, deleteResponse.getStatusCode());
+    }
+
+    @Test
+    void loginUser() {
+        //Create a user to test against.
+        UserAccount stevesAccount = new UserAccount("Steve", "Harrington", UserType.PLAYER, "Scoops", "icecream", "scoopes@email.com");
+        ResponseEntity<UserAccount> response = uac.addUserAccount(stevesAccount);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        //Try to login user with correct information.
+        ResponseEntity<String> loginResponse = uac.loginUser(new UserAccount(null,null,null,null,"icecream", "scoopes@email.com"));
+        assertEquals(HttpStatus.OK, loginResponse.getStatusCode());
+        //Try to login user with faulty username.
+        loginResponse = uac.loginUser(new UserAccount(null,null,null,null,"icecream12", "scoopes@email.com"));
+        assertEquals(HttpStatus.BAD_REQUEST, loginResponse.getStatusCode());
+        //Try to login user with faulty email.
+        loginResponse = uac.loginUser(new UserAccount(null,null,null,null,"icecream", "scoopes12@email.com"));
+        assertEquals(HttpStatus.BAD_REQUEST, loginResponse.getStatusCode());
+        //Delete the UserAccount again.
+        ResponseEntity<String> deleteResponse = uac.deleteUserAccount(response.getBody().getUserAccountId());
+        assertEquals(HttpStatus.OK, deleteResponse.getStatusCode());
+    }
+
     int createTestUserAccount() {
         ResponseEntity<UserAccount> response = uac.addUserAccount(new UserAccount());
         return response.getBody().getUserAccountId();


### PR DESCRIPTION
Added logic to ensure that both the email and the username is unique for each UserAccount. (UserAccount.java)
Added logic for login which determines if the email and password supplied to the database match an account already in the database. 
Added two new tests in UserAccountTests.java, which tests register user and login user.

Added a new setting to each table which fixes the name of a table. (This is needed if we want to do custom queries with HQL later).
